### PR TITLE
[GC-Stress] Updated root data store to periodically create child data store, reference / unreference them

### DIFF
--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -855,6 +855,7 @@ export class GarbageCollector implements IGarbageCollector {
             const gcResult = runGarbageCollection(gcData.gcNodes, ["/"]);
 
             const gcStats = await this.runPostGCSteps(gcData, gcResult, logger, currentReferenceTimestampMs);
+            console.log(`................. GC: ${gcStats.unrefDataStoreCount} / ${gcStats.dataStoreCount}`);
             event.end({ ...gcStats });
             this.completedRuns++;
             return gcStats;

--- a/packages/test/test-service-load/package.json
+++ b/packages/test/test-service-load/package.json
@@ -39,6 +39,7 @@
     "start:odspdf": "node ./dist/nodeStressTest.js --driver odsp --driverEndpoint odsp-df",
     "start:reauth": "node ./dist/nodeStressTest.js --profile mini --browserAuth",
     "start:t9s": "start-server-and-test start:tinylicious:test 7070 start:t9s:run",
+    "start:t9s:debug": "node ./dist/nodeStressTest.js --driver tinylicious --profile debug",
     "start:t9s:run": "node ./dist/nodeStressTest.js --driver tinylicious ",
     "start:tinylicious:test": "tinylicious > tinylicious.log 2>&1",
     "test": "npm run test:stress:run",
@@ -97,7 +98,8 @@
     "ps-node": "^0.1.6",
     "random-js": "^1.0.8",
     "start-server-and-test": "^1.11.7",
-    "tinylicious": "^0.4.89251"
+    "tinylicious": "^0.4.89251",
+    "uuid": "^8.3.1"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",

--- a/packages/test/test-service-load/package.json
+++ b/packages/test/test-service-load/package.json
@@ -40,6 +40,7 @@
     "start:reauth": "node ./dist/nodeStressTest.js --profile mini --browserAuth",
     "start:t9s": "start-server-and-test start:tinylicious:test 7070 start:t9s:run",
     "start:t9s:debug": "node ./dist/nodeStressTest.js --driver tinylicious --profile debug",
+    "start:t9s:gc": "node ./dist/nodeStressTest.js --driver tinylicious --profile gc",
     "start:t9s:run": "node ./dist/nodeStressTest.js --driver tinylicious ",
     "start:tinylicious:test": "tinylicious > tinylicious.log 2>&1",
     "test": "npm run test:stress:run",

--- a/packages/test/test-service-load/src/gcDataStore.ts
+++ b/packages/test/test-service-load/src/gcDataStore.ts
@@ -1,101 +1,155 @@
+/* eslint-disable jsdoc/check-indentation */
 /*!
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
 
+import { v4 as uuid } from "uuid";
 import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct";
 import { assert, delay } from "@fluidframework/common-utils";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { SharedCounter } from "@fluidframework/counter";
 import { IRunConfig } from "./loadTestDataStore";
 
+export interface IGCDataStore {
+    readonly handle: IFluidHandle;
+    run: (config: IRunConfig) => Promise<boolean>;
+    stop: () => void;
+}
+
 /**
- * DataObjectWithCounter increments a SharedCounter as a way of sending ops.
- *
- * The SharedCounter is retrieved via handle
+ * Base data object that creates and initializes a SharedCounter. This can be extended by all data objects
+ * to send ops by incrementing the counter.
  */
-const counterKey = "counter";
-export class DataObjectWithCounter extends DataObject {
-    private _counter?: SharedCounter;
-    protected isRunning: boolean = false;
+class BaseDataObject extends DataObject {
     public static get type(): string {
         return "DataObjectWithCounter";
     }
 
+    private readonly counterKey = "counter";
+    private _counter: SharedCounter | undefined;
     protected get counter(): SharedCounter {
-        assert(this._counter !== undefined, "Need counter to be defined before retreiving!");
+        assert(this._counter !== undefined, "Counter cannot be retrieving before initialization");
         return this._counter;
     }
 
-    protected async initializingFirstTime(props?: any): Promise<void> {
-        this.root.set<IFluidHandle>(counterKey, SharedCounter.create(this.runtime).handle);
+    protected async initializingFirstTime(): Promise<void> {
+        this.root.set<IFluidHandle>(this.counterKey, SharedCounter.create(this.runtime).handle);
     }
 
     protected async hasInitialized(): Promise<void> {
-        const handle = this.root.get<IFluidHandle<SharedCounter>>(counterKey);
-        assert(handle !== undefined, `The counter handle should exist on initialization!`);
+        const handle = this.root.get<IFluidHandle<SharedCounter>>(this.counterKey);
+        assert(handle !== undefined, "The counter handle should exist on initialization");
         this._counter = await handle.get();
-    }
-
-    public stop() {
-        this.isRunning = false;
-    }
-
-    // public start() {
-    //     this.run().catch((error) => { console.log(error); });
-    // }
-
-    public async run(config: IRunConfig) {
-        this.isRunning = true;
-        const delayPerOpMs = 60 * 1000 / config.testConfig.opRatePerMin;
-        // div by 2 for parent/child
-        const clientSendCount = config.testConfig.totalSendCount / config.testConfig.numClients / 2;
-        let localCount = 0;
-        while (this.isRunning && !this.disposed) {
-            this.counter.increment(1);
-            localCount++;
-            if (localCount % 3 === 1) {
-                console.log(
-                    `########## GC DATA STORE [${this.runtime.clientId}]: ${localCount} / ${this.counter.value}`);
-            }
-            if (localCount >= clientSendCount) {
-                break;
-            }
-            await delay(delayPerOpMs);
-        }
-        return true;
     }
 }
 
-export const dataObjectWithCounterFactory = new DataObjectFactory(
-    DataObjectWithCounter.type,
-    DataObjectWithCounter,
+/**
+ * Data object type 1 that does the following when asked to run:
+ * - It sends ops at a regular interval. The interval is defined by the config passed to the run method.
+ */
+export class DataObjectType1 extends BaseDataObject implements IGCDataStore {
+    public static get type(): string {
+        return "DataObjectType1";
+    }
+
+    private shouldRun: boolean = false;
+
+    public async run(config: IRunConfig) {
+        console.log("+++++++++ Starting child");
+        this.shouldRun = true;
+        const delayBetweenOpsMs = 60 * 1000 / config.testConfig.opRatePerMin;
+        while (this.shouldRun && !this.runtime.disposed) {
+            this.counter.increment(1);
+            await delay(delayBetweenOpsMs);
+        }
+        return !this.runtime.disposed;
+    }
+
+    public stop() {
+        console.log("+++++++++ Stopping child");
+        this.shouldRun = false;
+    }
+}
+
+export const dataObjectType1Factory = new DataObjectFactory(
+    DataObjectType1.type,
+    DataObjectType1,
     [SharedCounter.getFactory()],
     {},
 );
 
-export class DataObjectParent extends DataObjectWithCounter {
-    private child: DataObjectWithCounter | undefined;
+/**
+ * Root data object for the stress tests that does the following when asked to run:
+ * - It sends ops at a regular interval. The interval is defined by the config passed to the run method.
+ * - After every few ops, it does an activity. Example activities:
+ *     - Create a child data store, reference it and asks it to run.
+ *     - Ask a child data store to stop running and unreferenced it.
+ */
+export class RootDataObject extends BaseDataObject implements IGCDataStore {
     public static get type(): string {
-        return "DataObjectParent";
+        return "RootDataObject";
     }
-    protected async hasInitialized(): Promise<void> {
-        await super.hasInitialized();
 
-        this.child = await dataObjectWithCounterFactory.createInstance(this.context.containerRuntime);
-    }
+    private shouldRun: boolean = false;
+
+    private readonly uniqueChildKey = `${uuid()}-child`;
+    private child: IGCDataStore | undefined;
 
     public async run(config: IRunConfig) {
-        const childP = this.child?.run(config);
-        const parentP = super.run(config);
-        const allP = await Promise.all([childP, parentP]);
-        return allP.every((done) => done);
+        this.shouldRun = true;
+        const delayBetweenOpsMs = 60 * 1000 / config.testConfig.opRatePerMin;
+        const clientSendCount = config.testConfig.totalSendCount / config.testConfig.numClients;
+        let localSendCount = 0;
+
+        while (this.shouldRun && localSendCount < clientSendCount && !this.runtime.disposed) {
+            if (localSendCount % 3 === 0) {
+                console.log(
+                    `########## GC DATA STORE [${this.runtime.clientId}]: ${localSendCount} / ${this.counter.value}`);
+            }
+
+            // After every 3 ops, perform an activity.
+            if (localSendCount % 3 === 0) {
+                await this.preformActivity(config);
+            }
+
+            this.counter.increment(1);
+            localSendCount++;
+            await delay(delayBetweenOpsMs);
+        }
+        return !this.runtime.disposed;
+    }
+
+    public stop() {
+        this.shouldRun = false;
+    }
+
+    /**
+     * Perform the following activity:
+     * - Ask the current child data store to stop running and unreferenced it.
+     * - Create a child data store, reference it and asks it to run.
+     */
+    private async preformActivity(config: IRunConfig) {
+        this.child?.stop();
+        this.child = await dataObjectType1Factory.createInstance(this.context.containerRuntime);
+        // This will unreference the previous child and reference the new one.
+        this.root.set(this.uniqueChildKey, this.child.handle);
+
+        // Set up the child to send ops 10 times faster than this data store.
+        const childConfig: IRunConfig = { ...config };
+        childConfig.testConfig.opRatePerMin = config.testConfig.opRatePerMin * 10;
+
+        this.child.run(childConfig).then((done: boolean) => {
+            throw new Error("Child was disposed while running");
+        }).catch((error) => {
+            throw new Error(`Error when running child: ${error}`);
+        });
     }
 }
 
-export const dataObjectParentFactory = new DataObjectFactory(
-    DataObjectParent.type,
-    DataObjectParent,
+export const rootDataObjectFactory = new DataObjectFactory(
+    RootDataObject.type,
+    RootDataObject,
     [SharedCounter.getFactory()],
     {},
 );

--- a/packages/test/test-service-load/src/optionsMatrix.ts
+++ b/packages/test/test-service-load/src/optionsMatrix.ts
@@ -49,18 +49,18 @@ export const generateLoaderOptions =
     };
 
 const gcOptionsMatrix: OptionsMatrix<IGCRuntimeOptions> = {
-    disableGC: booleanCases,
-    gcAllowed: booleanCases,
-    runFullGC: booleanCases,
+    disableGC: [false],
+    gcAllowed: [true],
+    runFullGC: [false],
     sweepAllowed: [false],
     sessionExpiryTimeoutMs: [undefined], // Don't want coverage here
 };
 
 const summaryOptionsMatrix: OptionsMatrix<ISummaryRuntimeOptions> = {
     disableSummaries: [false],
-    initialSummarizerDelayMs: numberCases,
+    initialSummarizerDelayMs: [500],
     summaryConfigOverrides: [undefined],
-    maxOpsSinceLastSummary: numberCases,
+    maxOpsSinceLastSummary: [undefined],
     summarizerClientElection: booleanCases,
     summarizerOptions: [undefined],
 };

--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -1,5 +1,21 @@
 {
     "profiles": {
+        "gc": {
+            "opRatePerMin": 120,
+            "progressIntervalMs": 5000,
+            "numClients": 10,
+            "totalSendCount": 1000,
+            "readWriteCycleMs": 10000
+        },
+        "gc_fault": {
+            "opRatePerMin": 120,
+            "progressIntervalMs": 5000,
+            "numClients": 10,
+            "totalSendCount": 1000,
+            "readWriteCycleMs": 10000,
+            "faultInjectionMinMs": 0,
+            "faultInjectionMaxMs": 50000
+        },
         "ci": {
             "opRatePerMin": 10,
             "progressIntervalMs": 15000,


### PR DESCRIPTION
With this change, the general behavior of the test is that it creates data stores, references them and runs them. At the same time, it unreferences existing data stores and stops running them. It's a simple scenario and it basically validates that there are no unexpected errors without `reviving` data stores.

the test flow is the following:
- The `LoadTestDataStore` loads `RootDataObject` and runs it.
- The `RootDataObject` sends ops in a while loop with delay between each op. After every 3 ops (this will become configurable or will derive from a config), it does the following:
  - Stops the previous child data store from running.
  - Creates a new child data store of type `DataStoreType1`.
  - Unreferences previous child, references new child and runs the new child.
 - `DataStoreType1` child sends ops in a while loop with delay between each op. It sends ops 10 times faster than the parent (root) data store. It keeps doing this until stop is called.